### PR TITLE
[PKGBUILD] Depend on libxft-bgra

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,12 +2,12 @@
 _pkgname="dmenu"
 pkgname="$_pkgname-royarg-git"
 pkgver=5.1.r2.bd73af3
-pkgrel=1
+pkgrel=2
 pkgdesc="A modified version of the dynamic menu for X, originally designed for dwm."
 arch=('i686' 'x86_64')
 url="https://github.com/RoyARG02/$_pkgname"
 license=('MIT')
-depends=('sh' 'libxinerama' 'libxft')
+depends=('sh' 'libxinerama' 'libxft-bgra')
 makedepends=('git')
 provides=("$_pkgname")
 conflicts=("$_pkgname" "$_pkgname-git")
@@ -27,5 +27,5 @@ build() {
 package() {
 	cd "$_pkgname"
 	make PREFIX=/usr DESTDIR="$pkgdir/" install
-  install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$_pkgname/LICENSE
+	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$_pkgname/LICENSE
 }


### PR DESCRIPTION
This build of dmenu requires `libxft-bgra` for displaying emojis.