### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dmenu-royarg-git
 	pkgdesc = A modified version of the dynamic menu for X, originally designed for dwm.
-	pkgver = 5.1.r9.d768f7a
+	pkgver = 5.1.r10.46d53a6
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dmenu
 	install = dmenu-royarg-git.install

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dmenu"
 pkgname="$_pkgname-royarg-git"
-pkgver=5.1.r9.d768f7a
+pkgver=5.1.r10.46d53a6
 pkgrel=1
 pkgdesc="A modified version of the dynamic menu for X, originally designed for dwm."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit 46d53a6f5c7e29e2a67f3976403d1769b303f4b8
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sat Sep 10 13:29:34 2022 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit 1e8c5b68f4881bd4ae257c780fd41f129c79f419
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Sep 2 19:09:50 2022 +0200

        fix a regression in the previous commit for tab complete

        Reported by Santtu Lakkala <inz@inz.fi>, thanks!

    commit 528d39b011afb7ef6fd794ba6b74155d4e69bc68
    Author: NRK <nrk@disroot.org>
    Date:   Thu Sep 1 23:51:43 2022 +0600

        tab-complete: figure out the size before copying

        we already need to know the string length since `cursor` needs to be
        adjusted.

        so just calculate the length beforehand and use `memcpy` to copy exactly
        as much as needed (as opposed to `strncpy` which always writes `n`
        bytes).

    commit 32db2b125190d366be472ccb7cad833248696144
    Author: NRK <nrk@disroot.org>
    Date:   Fri Sep 2 00:35:18 2022 +0600

        readstdin: use getline(3)

        currently readstdin():
           - fgets() into a local buffer,
           - strchr() the buffer to eleminate the newline
           - stdups() the buffer into items

        a simpler way is to just use getline(3), which will do the allocation
        for us; eliminating the need for stdup()-ing.

        additionally getline returns back the amount of bytes read, which
        eliminates the need for strchr()-ing to find the newline.

