### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dmenu-royarg-git
 	pkgdesc = A modified version of the dynamic menu for X, originally designed for dwm.
-	pkgver = 5.2.r0.6801265
+	pkgver = 5.2.r1.e83d2bd
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dmenu
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dmenu"
 pkgname="$_pkgname-royarg-git"
-pkgver=5.2.r0.6801265
+pkgver=5.2.r1.e83d2bd
 pkgrel=1
 pkgdesc="A modified version of the dynamic menu for X, originally designed for dwm."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit e83d2bd1e979dc62b5e07883f2a894236e684892
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sat Nov 5 11:33:27 2022 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit ba1a347dcaba055f824161007dfee60db3ea785b
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Mon Oct 31 11:52:30 2022 +0100

        readstdin: allocate amount of items

        Keep track of the amount of items (not a total buffer size), allocate an array of
        new items. For now change BUFSIZ bytes to 256 * sizeof(struct item)).

    commit bcbc1ef5c4cf4875a4d66e7dc0919da88a6096a5
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Mon Oct 31 11:43:34 2022 +0100

        readstdin: add a comment

        Maybe too obvious / redundant, but OK.

    commit 689d9bfcf6859e5ce85c296ff0f23b5c08b1fedc
    Author: NRK <nrk@disroot.org>
    Date:   Mon Oct 31 00:10:45 2022 +0600

        fix leak when getline fails

        according to the getline(3) documentation, the calling code needs to
        free the buffer even if getline fails.

        dmenu currently doesn't do that which results in a small leak in case of
        failure (e.g when piped /dev/null)

            $ ./dmenu < /dev/null
            ==8201==ERROR: LeakSanitizer: detected memory leaks
            Direct leak of 120 byte(s) in 1 object(s) allocated from:
                #0 0x7f6bf5785ef7 in malloc
                #1 0x7f6bf538ec84 in __getdelim
                #2 0x405d0c in readstdin dmenu.c:557

        moving `line = NULL` inside the loop body wasn't strictly necessary, but
        IMO it makes it more apparent that `line` is getting cleared to NULL
        after each successful iteration.

    commit e42c03663442f5fb2f66dd59cc5bfdc61c53192c
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Wed Oct 26 09:43:17 2022 +0200

        dmenu: small XmbLookupString code improvements

        * Increase the length of composed strings to the same limit as st (32 to 64 bytes).
        * Initialize ksym to NoSymbol to be safe: currently this is not an issue though.
        * Add comments to clarify the return values of XmbLookupString a bit.
