### PR TITLE
Updates from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dmenu-royarg-git
 	pkgdesc = A modified version of the dynamic menu for X, originally designed for dwm.
-	pkgver = 5.2.r1.e83d2bd
+	pkgver = 5.2.r2.2f4590a
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dmenu
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dmenu"
 pkgname="$_pkgname-royarg-git"
-pkgver=5.2.r1.e83d2bd
+pkgver=5.2.r2.2f4590a
 pkgrel=1
 pkgdesc="A modified version of the dynamic menu for X, originally designed for dwm."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit 2f4590a7300ca028d7e8cd562d5152daf40bc87b
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sun Mar 12 12:48:53 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit dfbbf7f6e1b22ccf9e5a45d77ee10995577fb4fc
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Wed Mar 8 21:20:52 2023 +0100
    
        readstdin: reduce memory-usage by duplicating the line from getline()
    
        Improves upon commit 32db2b125190d366be472ccb7cad833248696144
    
        The getline() implementation often uses a more greedy way of allocating memory.
        Using this buffer directly and forcing an allocation (by setting it to NULL)
        would waste a bit of extra space, depending on the implementation of course.
    
        Tested on musl libc and glibc.
        The current glibc version allocates a minimum of 120 bytes per line.
        For smaller lines musl libc seems less wasteful but still wastes a few bytes
        per line.
    
        On a dmenu_path listing on my system the memory usage was about 350kb (old) vs
        30kb (new) on Void Linux glibc.
    
        Side-note that getline() also reads NUL bytes in lines, while strdup() would
        read until the NUL byte. Since dmenu reads text lines either is probably
        fine(tm). Also rename junk to linesiz.
