### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dmenu-royarg-git
 	pkgdesc = A modified version of the dynamic menu for X, originally designed for dwm.
-	pkgver = 5.2.r10.dd80f07
+	pkgver = 5.2.r11.bb0d78a
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dmenu
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dmenu"
 pkgname="$_pkgname-royarg-git"
-pkgver=5.2.r10.dd80f07
+pkgver=5.2.r11.bb0d78a
 pkgrel=1
 pkgdesc="A modified version of the dynamic menu for X, originally designed for dwm."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit bb0d78a88aa7a3ce452f1e3479a393a3e2d101fc
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Wed Apr 12 14:52:33 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit 0fe460dbd469a1d5b6a7140d0e1801935e4a923b
    Author: Lucas de Sena <lucas@seninha.org>
    Date:   Wed Apr 5 17:11:49 2023 -0300
    
        fix BadMatch error when embedding on some windows
    
        When embedded into another window, dmenu will fail with the BadMatch
        error if that window have not the same colormap/depth/visual as the
        root window.
    
        That happens because dmenu inherits the colormap/depth/visual from
        its parent, but draws on a pixmap created based on the root window
        using a GC created for the root window (see drw.c).  A BadMatch will
        occur when copying the content of the pixmap into dmenu's window.
    
        A solution is to create dmenu's window inside root and then reparent
        it if embeded.
    
        See this mail[1] on ports@openbsd.org mailing list for context.
    
        [1]: https://marc.info/?l=openbsd-ports&m=168072150814664&w=2
